### PR TITLE
Add pcl to find package

### DIFF
--- a/bezier_examples/CMakeLists.txt
+++ b/bezier_examples/CMakeLists.txt
@@ -14,6 +14,7 @@ find_package(catkin REQUIRED COMPONENTS
   tf
   tf_conversions
   visualization_msgs
+  PCL
 )
 
 ################################################


### PR DESCRIPTION
When making this package it does not properly link against PCL - adding PCL to the find_package script ensures it does.